### PR TITLE
Fix/friends cards layour shift

### DIFF
--- a/src/components/Film/FilmBadge.tsx
+++ b/src/components/Film/FilmBadge.tsx
@@ -31,7 +31,7 @@ const FilmBadge = ({ rating, isColorfulBadge }: FilmBadgeProps) => {
 
     return (
         <div
-            class={`absolute text-black flex flex-col items-center text-base gap-1 p-2 min-w-[32px] right-0 top-0 rounded-tl-sm rounded-br-sm rounded-tr-lg rounded-bl-lg ${ratingColor}`}
+            class={`css-film-badge absolute text-black flex flex-col items-center text-base gap-1 p-2 min-w-[32px] right-0 top-0 rounded-tl-sm rounded-br-sm rounded-tr-lg rounded-bl-lg ${ratingColor}`}
         >
             {rating ? Number(rating).toFixed(1) : "?"}
         </div>

--- a/src/components/Film/FilmData.tsx
+++ b/src/components/Film/FilmData.tsx
@@ -11,7 +11,9 @@ export const FilmDataLarge = ({ film }: FilmDataProps) => {
     const cardHight = film.extraData.friendData ? "h-36" : "h-28";
 
     return (
-        <div class={`text-gray-400 w-full rounded-md text-lg mt-4 flex flex-col justify-between ${cardHight}`}>
+        <div
+            class={`css-film-data-large text-gray-400 w-full rounded-md text-lg mt-4 flex flex-col justify-between ${cardHight}`}
+        >
             <div class="line-clamp-2 text-lg leading-tight text-white" title={filmTitle}>
                 {filmTitle}
             </div>
@@ -71,7 +73,7 @@ export const FilmDataSmall = ({ film }: FilmDataProps) => {
                                 <HeartIcon />
                             </div>
                         )}
-                        <div title="rating" class={filmExtraData.ratingElementClasses?.replace(/-micro\b/, '')}></div>
+                        <div title="rating" class={filmExtraData.ratingElementClasses?.replace(/-micro\b/, "")}></div>
                     </div>
                 )}
             </div>

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -3,14 +3,15 @@ import { defineManifest } from "@crxjs/vite-plugin";
 const manifest = defineManifest({
     manifest_version: 3,
     name: "Letterboxd Tweaks",
-    description: "Enhance Letterboxd with cleaner movie cards, instant search suggestions, and various quality of life improvements.",
-    version: "0.0.6",
+    description:
+        "Enhance Letterboxd with cleaner movie cards, instant search suggestions, and various quality of life improvements.",
+    version: "0.0.7",
     permissions: ["storage"],
     icons: {
-        '16': 'icons/logo-16.png',
-        '32': 'icons/logo-32.png',
-        '48': 'icons/logo-48.png',
-        '128': 'icons/logo-128.png'
+        "16": "icons/logo-16.png",
+        "32": "icons/logo-32.png",
+        "48": "icons/logo-48.png",
+        "128": "icons/logo-128.png"
     },
     background: {
         service_worker: "src/pages/background/index.ts",
@@ -29,10 +30,10 @@ const manifest = defineManifest({
     ],
     web_accessible_resources: [
         {
-          resources: ['icons/logo-16.png', 'icons/logo-32.png', 'icons/logo-48.png', 'icons/logo-128.png'],
-          matches: []
+            resources: ["icons/logo-16.png", "icons/logo-32.png", "icons/logo-48.png", "icons/logo-128.png"],
+            matches: []
         }
-      ]
+    ]
 });
 
 export default manifest;

--- a/src/options/films/filmsUtils.ts
+++ b/src/options/films/filmsUtils.ts
@@ -76,7 +76,7 @@ export class Film {
             small: [
                 "body.films-watched ul.-p70",
                 "div#films-browser-list-container ul.-p70",
-                "div.likes-page-content ul.-p70:not(.-overlapped)"
+                "div.likes-page-content ul.-p70:not(.-overlapped)" // /<user>/likes/films/ page
             ],
             micro: [
                 "[data-object-name='review']",

--- a/src/options/films/filmsUtils.ts
+++ b/src/options/films/filmsUtils.ts
@@ -80,7 +80,7 @@ export class Film {
             ],
             micro: [
                 "[data-object-name='review']",
-                "body.list-page ul.-p70.film-details-list",
+                "body.list-page div.viewing-list",
                 "section#live-feed ul.-p70",
                 "section#crew-picks-sidebar ul.-p70",
                 "body.search-results ul.results > li > div.film-poster"

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -16,3 +16,7 @@ body.profile .js-metadatum > svg,
 .like-link-target button > svg {
     display: inline-block;
 }
+
+.production-record  {
+    grid-template-columns: max-content auto !important;
+}


### PR DESCRIPTION
Closes #35
Closes #36 

Fixes:
- Friends cards layout shifts
<img src="https://github.com/user-attachments/assets/b2fb90ef-97b1-4973-92c3-ff5d18887093" />
<img src="https://github.com/user-attachments/assets/84396b8a-f699-4bbf-9646-36f75721307f" />

- film cards not visible on likes page
- poster disappeared on list pages, popular reviews this week, recent reviews - user profile + activity
![image](https://github.com/user-attachments/assets/c6523914-736b-489c-8448-261448ee06a4)
![image](https://github.com/user-attachments/assets/b07e2c41-0b2c-4511-9fec-7aa0c2d2770d)
