### PR TITLE
fix: attribution block still visible on new from friends

### DIFF
--- a/src/options/films/filmsUtils.ts
+++ b/src/options/films/filmsUtils.ts
@@ -368,6 +368,10 @@ export class Film {
                     #popular-with-friends .poster-list {
                         flex-wrap: nowrap;
                     }
+                    
+                    .poster.-attributed {
+                        padding: 0;
+                    }
 
                     .poster.-attributed > div {
                         padding-bottom: 0;


### PR DESCRIPTION
Before: 
<img width="172" height="338" alt="image" src="https://github.com/user-attachments/assets/fb61f7e2-c5ea-483e-b855-896e2a62e1d9" />

After:
<img width="160" height="316" alt="image" src="https://github.com/user-attachments/assets/66d0b5c6-ecea-45cc-9cbb-c76213fcde58" />
